### PR TITLE
Adds support for Intercom Help Center endpoints. Articles, Collections and Sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,6 +593,110 @@ client.notes.list({ email: 'bob@intercom.io' }, callback);
 client.notes.find({ id: '3342887' }, callback);
 ```
 
+## Articles
+```node
+// Create an article
+let article = {
+  title: 'Article title',
+  body: '<p>Article body</p>',
+  author_id: 21599
+}
+client.articles.create(article, callback)
+```
+
+```node
+// Retrieve an article by ID
+client.articles.find(21, callback)
+```
+
+```node
+// Update an article
+let article = {
+  title: 'New title',
+  body: '<p>New body</p>',
+  author_id: 21599
+}
+client.articles.update(21, article, callback)
+```
+
+```node
+// Delete an article
+client.articles.delete(21, callback)
+```
+
+```node
+// List all articles
+client.articles.list(callback)
+```
+
+## Collections
+```node
+// Create a collection
+let collection = {
+  name: 'Collection name',
+  description: 'Description'
+}
+client.collections.create(collection, callback)
+```
+
+```node
+// Retrieve a collection by ID
+client.collections.find(21, callback)
+```
+
+```node
+// Update a collection
+let collection = {
+  name: 'New name',
+  description: 'New description'
+}
+client.collections.update(21, collection, callback)
+```
+
+```node
+// Delete a collection
+client.collections.delete(21, callback)
+```
+
+```node
+// List all collections
+client.collections.list(callback)
+```
+
+## Sections
+```node
+// Create a section
+let section = {
+  name: 'Section name',
+  parent_id: 3
+}
+client.sections.create(section, callback)
+```
+
+```node
+// Retrieve a section by ID
+client.sections.find(21, callback)
+```
+
+```node
+// Update a section
+let section = {
+  name: 'New name',
+  parent_id: 4
+}
+client.sections.update(21, section, callback)
+```
+
+```node
+// Delete a section
+client.sections.delete(21, callback)
+```
+
+```node
+// List all sections
+client.sections.list(callback)
+```
+
 ## Pagination
 
 When listing, the Intercom API may return a pagination object:

--- a/lib/article.js
+++ b/lib/article.js
@@ -1,0 +1,20 @@
+export default class Article {
+  constructor(client) {
+    this.client = client;
+  }
+  create(data, f) {
+    return this.client.post('/articles', data, f);
+  }
+  find(id, f) {
+    return this.client.get(`/articles/${id}`, {}, f);
+  }
+  update(id, params, f) {
+    return this.client.put(`/articles/${id}`, params, f);
+  }
+  delete(id, f) {
+    return this.client.delete(`/articles/${id}`, {}, f);
+  }
+  list(f) {
+    return this.client.get('/articles', {}, f);
+  }
+}

--- a/lib/client.js
+++ b/lib/client.js
@@ -15,6 +15,9 @@ import Message from './message';
 import Conversation from './conversation';
 import Note from './note';
 import Customer from './customer';
+import Article from './article';
+import Collection from './collection';
+import Section from './section';
 
 export default class Client {
   constructor(...args) {
@@ -47,6 +50,9 @@ export default class Client {
     this.conversations = new Conversation(this);
     this.notes = new Note(this);
     this.customers = new Customer(this);
+    this.articles = new Article(this);
+    this.collections = new Collection(this);
+    this.sections = new Section(this);
     this.promises = false;
     this.requestOpts = {
       baseUrl: 'https://api.intercom.io'

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -1,0 +1,20 @@
+export default class Collection {
+  constructor(client) {
+    this.client = client;
+  }
+  create(data, f) {
+    return this.client.post('/help_center/collections', data, f);
+  }
+  find(id, f) {
+    return this.client.get(`/help_center/collections/${id}`, {}, f);
+  }
+  update(id, params, f) {
+    return this.client.put(`/help_center/collections/${id}`, params, f);
+  }
+  delete(id, f) {
+    return this.client.delete(`/help_center/collections/${id}`, {}, f);
+  }
+  list(f) {
+    return this.client.get('/help_center/collections', {}, f);
+  }
+}

--- a/lib/section.js
+++ b/lib/section.js
@@ -1,0 +1,20 @@
+export default class Section {
+  constructor(client) {
+    this.client = client;
+  }
+  create(data, f) {
+    return this.client.post('/help_center/sections', data, f);
+  }
+  find(id, f) {
+    return this.client.get(`/help_center/sections/${id}`, {}, f);
+  }
+  update(id, params, f) {
+    return this.client.put(`/help_center/sections/${id}`, params, f);
+  }
+  delete(id, f) {
+    return this.client.delete(`/help_center/sections/${id}`, {}, f);
+  }
+  list(f) {
+    return this.client.get('/help_center/sections', {}, f);
+  }
+}

--- a/test/article.js
+++ b/test/article.js
@@ -1,0 +1,46 @@
+import assert from 'assert';
+import {Client} from '../lib';
+import nock from 'nock';
+
+describe('articles', () => {
+  it('should create an article', done => {
+    nock('https://api.intercom.io').post('/articles', { title: 'Article Title', body: '<p>Article body</p>', author_id: 5534534 }).reply(200, {});
+    const client = new Client('foo', 'bar').usePromises();
+    client.articles.create({ title: 'Article Title', body: '<p>Article body</p>', author_id: 5534534 }).then(r => {
+      assert.equal(200, r.statusCode);
+      done();
+    });
+  });
+  it('should retrieve an article', done => {
+    nock('https://api.intercom.io').get('/articles/baz').reply(200, {});
+    const client = new Client('foo', 'bar').usePromises();
+    client.articles.find('baz').then(r => {
+      assert.equal(200, r.statusCode);
+      done();
+    });
+  });
+  it('should update an article', done => {
+    nock('https://api.intercom.io').put('/articles/baz', { title: 'New title', body: '<p>New body</p>', author_id: 5534534 }).reply(200, {});
+    const client = new Client('foo', 'bar').usePromises();
+    client.articles.update('baz', { title: 'New title', body: '<p>New body</p>', author_id: 5534534 }).then(r => {
+      assert.equal(200, r.statusCode);
+      done();
+    });
+  });
+  it('should delete an article', done => {
+    nock('https://api.intercom.io').delete('/articles/baz').reply(200, {});
+    const client = new Client('foo', 'bar').usePromises();
+    client.articles.delete('baz').then(r => {
+      assert.equal(200, r.statusCode);
+      done();
+    });
+  });
+  it('should list all articles', done => {
+    nock('https://api.intercom.io').get('/articles').reply(200, {});
+    const client = new Client('foo', 'bar').usePromises();
+    client.articles.list().then(r => {
+      assert.equal(200, r.statusCode);
+      done();
+    });
+  });
+});

--- a/test/collection.js
+++ b/test/collection.js
@@ -1,0 +1,46 @@
+import assert from 'assert';
+import {Client} from '../lib';
+import nock from 'nock';
+
+describe('collections', () => {
+  it('should create a collection', done => {
+    nock('https://api.intercom.io').post('/help_center/collections', { name: 'My collection', description: 'Collection of my articles' }).reply(200, {});
+    const client = new Client('foo', 'bar').usePromises();
+    client.collections.create({ name: 'My collection', description: 'Collection of my articles' }).then(r => {
+      assert.equal(200, r.statusCode);
+      done();
+    });
+  });
+  it('should retrieve a collection', done => {
+    nock('https://api.intercom.io').get('/help_center/collections/baz').reply(200, {});
+    const client = new Client('foo', 'bar').usePromises();
+    client.collections.find('baz').then(r => {
+      assert.equal(200, r.statusCode);
+      done();
+    });
+  });
+  it('should update a collection', done => {
+    nock('https://api.intercom.io').put('/help_center/collections/baz', { name: 'New name', description: 'New description' }).reply(200, {});
+    const client = new Client('foo', 'bar').usePromises();
+    client.collections.update('baz', { name: 'New name', description: 'New description' }).then(r => {
+      assert.equal(200, r.statusCode);
+      done();
+    });
+  });
+  it('should delete a collection', done => {
+    nock('https://api.intercom.io').delete('/help_center/collections/baz').reply(200, {});
+    const client = new Client('foo', 'bar').usePromises();
+    client.collections.delete('baz').then(r => {
+      assert.equal(200, r.statusCode);
+      done();
+    });
+  });
+  it('should list all collections', done => {
+    nock('https://api.intercom.io').get('/help_center/collections').reply(200, {});
+    const client = new Client('foo', 'bar').usePromises();
+    client.collections.list().then(r => {
+      assert.equal(200, r.statusCode);
+      done();
+    });
+  });
+});

--- a/test/section.js
+++ b/test/section.js
@@ -1,0 +1,46 @@
+import assert from 'assert';
+import {Client} from '../lib';
+import nock from 'nock';
+
+describe('collections', () => {
+  it('should create a section', done => {
+    nock('https://api.intercom.io').post('/help_center/sections', { name: 'Section name', parent_id: 1 }).reply(200, {});
+    const client = new Client('foo', 'bar').usePromises();
+    client.sections.create({ name: 'Section name', parent_id: 1 }).then(r => {
+      assert.equal(200, r.statusCode);
+      done();
+    });
+  });
+  it('should retrieve a section', done => {
+    nock('https://api.intercom.io').get('/help_center/sections/baz').reply(200, {});
+    const client = new Client('foo', 'bar').usePromises();
+    client.sections.find('baz').then(r => {
+      assert.equal(200, r.statusCode);
+      done();
+    });
+  });
+  it('should update a section', done => {
+    nock('https://api.intercom.io').put('/help_center/sections/baz', { name: 'New name', parent_id: 2 }).reply(200, {});
+    const client = new Client('foo', 'bar').usePromises();
+    client.sections.update('baz', { name: 'New name', parent_id: 2 }).then(r => {
+      assert.equal(200, r.statusCode);
+      done();
+    });
+  });
+  it('should delete a section', done => {
+    nock('https://api.intercom.io').delete('/help_center/sections/baz').reply(200, {});
+    const client = new Client('foo', 'bar').usePromises();
+    client.sections.delete('baz').then(r => {
+      assert.equal(200, r.statusCode);
+      done();
+    });
+  });
+  it('should list all sections', done => {
+    nock('https://api.intercom.io').get('/help_center/sections').reply(200, {});
+    const client = new Client('foo', 'bar').usePromises();
+    client.sections.list().then(r => {
+      assert.equal(200, r.statusCode);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
#### Why?
Adding support for all Help Center endpoints - [Articles](https://developers.intercom.com/intercom-api-reference/reference#the-article-model), [Collections](https://developers.intercom.com/intercom-api-reference/reference#create-a-collection) and [Sections](https://developers.intercom.com/intercom-api-reference/reference#create-a-section). 

#### How?
Using existing patterns to add `create`, `find`, `update`, `delete` and `list`  methods for each of the three Help Center modules
